### PR TITLE
Fix MIME type for APKG download to prevent double extension on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -684,9 +684,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,9 +701,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +718,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +735,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,9 +752,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +769,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2262,9 +2244,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2286,9 +2265,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2310,9 +2286,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2334,9 +2307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/services/zipExporter.ts
+++ b/src/services/zipExporter.ts
@@ -388,7 +388,7 @@ export async function createDeckZip(cards: Card[], options: ZipExportOptions = {
     templateZip.file("collection.anki2", updatedCollection);
     templateZip.file("media", JSON.stringify(mediaMap));
 
-    return templateZip.generateAsync({ type: "blob" });
+    return templateZip.generateAsync({ type: "blob", mimeType: "application/octet-stream" });
   } finally {
     db.close();
   }
@@ -396,7 +396,8 @@ export async function createDeckZip(cards: Card[], options: ZipExportOptions = {
 
 export async function downloadDeckZip(cards: Card[], deckName: string, deckId?: number): Promise<void> {
   const apkgBlob = await createDeckZip(cards, { deckName, deckId });
-  const url = URL.createObjectURL(apkgBlob);
+  const safeBlob = new Blob([apkgBlob], { type: "application/octet-stream" });
+  const url = URL.createObjectURL(safeBlob);
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = `${sanitizeFileBaseName(deckName)}.apkg`;


### PR DESCRIPTION
This pull request updates the way deck ZIP files are generated and downloaded to ensure the correct MIME type is set, which improves compatibility and reliability when users download `.apkg` files.

**Export and download improvements:**

* Set the MIME type to `"application/octet-stream"` when generating the ZIP file in `createDeckZip`, ensuring the file is recognized as a binary file during downloads.
* Wrap the exported blob in a new `Blob` with the correct MIME type before creating the download URL in `downloadDeckZip`, further enforcing the correct file type for user downloads.