### PR TITLE
Disable default scrolling behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -168,19 +168,56 @@ body {
 }
 
 /* ---- Canvasラッパー ---- */
+.canvas-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.canvas-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid #d7dde5;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.canvas-toolbar__label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #445;
+}
+
+.canvas-toolbar__value {
+  min-width: 4rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #0056b3;
+}
+
+.canvas-toolbar__button {
+  padding: 0.28rem 0.65rem;
+  font-size: 0.82rem;
+}
+
 .canvas-wrapper {
   border: 1px solid #ccc;
   border-radius: 6px;
   overflow: auto;
   background: #fff;
-  max-height: 60vh;
+  width: 100%;
+  height: clamp(280px, 62svh, 720px);
   display: flex;
   align-items: flex-start;
+  justify-content: flex-start;
 }
 
 .canvas-wrapper canvas {
   display: block;
-  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 /* ---- ボタン ---- */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { cropImage } from "./services/imageCropper";
 import { loadDeckApkgAsSession } from "./services/fileManager";
 import { downloadSession, loadSession } from "./services/sessionManager";
 import { downloadDeckZip, sanitizeFileBaseName } from "./services/zipExporter";
-import type { Rect, Session } from "./types";
+import type { Rect, Session, ZoomLevel } from "./types";
 import "./App.css";
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -39,6 +39,8 @@ function App() {
   const [answerText, setAnswerText] = useState<string>("");
   const [questionSelection, setQuestionSelection] = useState<Rect | null>(null);
   const [answerSelection, setAnswerSelection] = useState<Rect | null>(null);
+  const [questionZoom, setQuestionZoom] = useState<ZoomLevel>("fit");
+  const [answerZoom, setAnswerZoom] = useState<ZoomLevel>("fit");
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [zipError, setZipError] = useState<string | null>(null);
 
@@ -66,6 +68,7 @@ function App() {
         setQuestionSelection(null);
         setQuestionImageDims(null);
         setQuestionSelectAll(false);
+        setQuestionZoom("fit");
       } catch (error) {
         const detail = error instanceof Error ? error.message : "不明なエラー";
         setSessionError(`問題画像の読み込みに失敗しました: ${detail}`);
@@ -84,6 +87,7 @@ function App() {
         setAnswerSelection(null);
         setAnswerImageDims(null);
         setAnswerSelectAll(false);
+        setAnswerZoom("fit");
       } catch (error) {
         const detail = error instanceof Error ? error.message : "不明なエラー";
         setSessionError(`解答画像の読み込みに失敗しました: ${detail}`);
@@ -209,6 +213,8 @@ function App() {
         setAnswerImageDims(null);
         setQuestionSelectAll(false);
         setAnswerSelectAll(false);
+        setQuestionZoom("fit");
+        setAnswerZoom("fit");
         setSessionError(null);
       } catch (error) {
         const detail = error instanceof Error ? error.message : "不明なエラー";
@@ -250,6 +256,8 @@ function App() {
         setAnswerImageDims(null);
         setQuestionSelectAll(false);
         setAnswerSelectAll(false);
+        setQuestionZoom("fit");
+        setAnswerZoom("fit");
         setSessionError(null);
       } catch (error) {
         const detail = error instanceof Error ? error.message : "不明なエラー";
@@ -372,14 +380,14 @@ function App() {
 
           {questionImageSrc ? (
             <>
-              <div className="canvas-wrapper">
-                <CanvasSelector
-                  imageSrc={questionImageSrc}
-                  onSelect={handleQuestionSelect}
-                  selection={questionSelection}
-                  onImageLoad={handleQuestionImageLoad}
-                />
-              </div>
+              <CanvasSelector
+                imageSrc={questionImageSrc}
+                onSelect={handleQuestionSelect}
+                selection={questionSelection}
+                onImageLoad={handleQuestionImageLoad}
+                zoom={questionZoom}
+                onZoomChange={setQuestionZoom}
+              />
               <label className="select-all-label">
                 <input
                   type="checkbox"
@@ -472,14 +480,14 @@ function App() {
 
           {answerImageSrc ? (
             <>
-              <div className="canvas-wrapper">
-                <CanvasSelector
-                  imageSrc={answerImageSrc}
-                  onSelect={handleAnswerSelect}
-                  selection={answerSelection}
-                  onImageLoad={handleAnswerImageLoad}
-                />
-              </div>
+              <CanvasSelector
+                imageSrc={answerImageSrc}
+                onSelect={handleAnswerSelect}
+                selection={answerSelection}
+                onImageLoad={handleAnswerImageLoad}
+                zoom={answerZoom}
+                onZoomChange={setAnswerZoom}
+              />
               <label className="select-all-label">
                 <input
                   type="checkbox"

--- a/src/components/CanvasSelector.tsx
+++ b/src/components/CanvasSelector.tsx
@@ -4,7 +4,7 @@
  * useSelectionフックでロジックを管理し、UIはCanvasへの描画のみを担う。
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSelection } from "../hooks/useSelection";
 import type { CanvasSelectorProps, Rect } from "../types";
 
@@ -16,6 +16,10 @@ const SELECTION_STYLE = {
   draftStrokeColor: "rgba(0, 120, 255, 0.6)",
   draftFillColor: "rgba(0, 120, 255, 0.08)",
 } as const;
+
+const ZOOM_STEP = 1.25;
+const MIN_ZOOM = 0.2;
+const MAX_ZOOM = 4;
 
 /**
  * Canvasに矩形を描画する補助関数。
@@ -50,9 +54,15 @@ export function CanvasSelector({
   width,
   height,
   onImageLoad,
+  zoom,
+  onZoomChange,
 }: CanvasSelectorProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const canvasWrapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
+  const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(null);
+  const [imageSize, setImageSize] = useState<{ width: number; height: number } | null>(null);
 
   const {
     draft,
@@ -68,6 +78,63 @@ export function CanvasSelector({
   // 外部から制御する場合は外部の値、なければ内部状態を使う
   const activeSelection = externalSelection !== undefined ? externalSelection : internalSelection;
 
+  useEffect(() => {
+    const element = canvasWrapRef.current;
+    if (!element) return;
+
+    const updateSize = () => {
+      setContainerSize({ width: element.clientWidth, height: element.clientHeight });
+    };
+
+    updateSize();
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const fitScale = useMemo(() => {
+    if (!containerSize || !imageSize) return 1;
+    const scaleX = containerSize.width / imageSize.width;
+    const scaleY = containerSize.height / imageSize.height;
+    return Math.min(scaleX, scaleY);
+  }, [containerSize, imageSize]);
+
+  const displayScale = zoom === "fit" ? fitScale : zoom;
+  const canvasWidth = imageSize?.width ?? 0;
+  const canvasHeight = imageSize?.height ?? 0;
+  const canvasStyle = useMemo(
+    () => ({
+      cursor: "crosshair",
+      display: "block",
+      touchAction: "none",
+      width: `${canvasWidth * displayScale}px`,
+      height: `${canvasHeight * displayScale}px`,
+    }),
+    [canvasHeight, canvasWidth, displayScale]
+  );
+
+  const displayedZoomText = `${Math.round(displayScale * 100)}%`;
+
+  const handleZoomIn = () => {
+    const currentScale = zoom === "fit" ? fitScale : zoom;
+    onZoomChange(Math.min(currentScale * ZOOM_STEP, MAX_ZOOM));
+  };
+
+  const handleZoomOut = () => {
+    const currentScale = zoom === "fit" ? fitScale : zoom;
+    onZoomChange(Math.max(currentScale / ZOOM_STEP, MIN_ZOOM));
+  };
+
+  const handleZoom100 = () => {
+    onZoomChange(1);
+  };
+
+  const handleZoomFit = () => {
+    onZoomChange("fit");
+  };
+
   // 画像の読み込みとCanvasサイズ設定
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -77,8 +144,11 @@ export function CanvasSelector({
     img.src = imageSrc;
     img.onload = () => {
       imageRef.current = img;
-      canvas.width = width ?? img.naturalWidth;
-      canvas.height = height ?? img.naturalHeight;
+      const nextWidth = width ?? img.naturalWidth;
+      const nextHeight = height ?? img.naturalHeight;
+      canvas.width = nextWidth;
+      canvas.height = nextHeight;
+      setImageSize({ width: nextWidth, height: nextHeight });
       onImageLoad?.(canvas.width, canvas.height);
       renderCanvas();
     };
@@ -127,15 +197,35 @@ export function CanvasSelector({
   }
 
   return (
-    <canvas
-      ref={canvasRef}
-      onMouseDown={onMouseDown}
-      onMouseMove={onMouseMove}
-      onMouseUp={onMouseUp}
-      onTouchStart={onTouchStart}
-      onTouchMove={onTouchMove}
-      onTouchEnd={onTouchEnd}
-      style={{ cursor: "crosshair", maxWidth: "100%", display: "block", touchAction: "none" }}
-    />
+    <div className="canvas-panel" ref={panelRef}>
+      <div className="canvas-toolbar" aria-label="画像表示倍率の操作">
+        <span className="canvas-toolbar__label">表示倍率</span>
+        <span className="canvas-toolbar__value">{displayedZoomText}</span>
+        <button type="button" className="btn btn--secondary canvas-toolbar__button" onClick={handleZoomOut}>
+          -
+        </button>
+        <button type="button" className="btn btn--secondary canvas-toolbar__button" onClick={handleZoomIn}>
+          +
+        </button>
+        <button type="button" className="btn btn--secondary canvas-toolbar__button" onClick={handleZoom100}>
+          100%
+        </button>
+        <button type="button" className="btn btn--secondary canvas-toolbar__button" onClick={handleZoomFit}>
+          Fit
+        </button>
+      </div>
+      <div className="canvas-wrapper" ref={canvasWrapRef}>
+        <canvas
+          ref={canvasRef}
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          style={canvasStyle}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/CanvasSelector.tsx
+++ b/src/components/CanvasSelector.tsx
@@ -57,7 +57,6 @@ export function CanvasSelector({
   zoom,
   onZoomChange,
 }: CanvasSelectorProps) {
-  const panelRef = useRef<HTMLDivElement>(null);
   const canvasWrapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
@@ -197,7 +196,7 @@ export function CanvasSelector({
   }
 
   return (
-    <div className="canvas-panel" ref={panelRef}>
+    <div className="canvas-panel">
       <div className="canvas-toolbar" aria-label="画像表示倍率の操作">
         <span className="canvas-toolbar__label">表示倍率</span>
         <span className="canvas-toolbar__value">{displayedZoomText}</span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,9 @@ export type Rect = {
   height: number;
 };
 
+/** 画像表示のズーム倍率 */
+export type ZoomLevel = number | "fit";
+
 /** 問題・解答のペア */
 export type Card = {
   id: string;
@@ -52,6 +55,10 @@ export type CanvasSelectorProps = {
   height?: number;
   /** 画像読み込み完了時のコールバック（Canvasのピクセル幅・高さを受け取る） */
   onImageLoad?: (width: number, height: number) => void;
+  /** 表示倍率（fit または 100%ベースの数値倍率） */
+  zoom: ZoomLevel;
+  /** 表示倍率の変更コールバック */
+  onZoomChange: (zoom: ZoomLevel) => void;
 };
 
 /** useSelectionフックの戻り値 */


### PR DESCRIPTION
This pull request introduces a zoom feature for the image selection canvas, allowing users to adjust the display scale of question and answer images. The main changes include adding zoom controls to the `CanvasSelector` component, updating its props and internal logic, and enhancing the UI for zoom interaction and responsiveness.

**Zoom functionality and UI enhancements:**

* Added a `ZoomLevel` type and new props (`zoom`, `onZoomChange`) to `CanvasSelector`, enabling external control of image zoom and synchronizing zoom state with the main app. (`src/types/index.ts` [[1]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R14-R16) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R58-R61); `src/App.tsx` [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L15-R15) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R42-R43) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R71) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R90) [[7]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R216-R217) [[8]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R259-R260) [[9]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L375-L382) [[10]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L475-L482)
* Implemented zoom control UI (buttons for zoom in, zoom out, 100%, and fit) and logic for scaling the canvas and image display, including maintaining container and image size and updating the displayed zoom percentage. (`src/components/CanvasSelector.tsx` [[1]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fL7-R7) [[2]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fR20-R23) [[3]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fR57-R65) [[4]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fR81-R137) [[5]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fL80-R151) [[6]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fR200-R217) [[7]](diffhunk://#diff-d628b957289818f7c85f921ca5cc8dfbb4f81ca57f9805502dd3cdaaa8c7b66fL138-R229)
* Updated CSS to style the new zoom toolbar and ensure the canvas panel and wrapper are responsive to zoom and layout changes. (`src/App.css` [src/App.cssR171-R220](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972R171-R220))