### PR TITLE
Fix card deduplication by using stable Anki GUIDs

### DIFF
--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -6,8 +6,6 @@ import { normalizeDeckUuid } from "../utils/deckUuid";
 import { generateId } from "../utils/idGenerator";
 
 const DEFAULT_DECK_NAME = "deck";
-const APKG_CARD_ID_PREFIX = "apkg-";
-const APKG_CARD_ID_PADDING = 6;
 const DEFAULT_CARD_NUMBER_PADDING = 4;
 const MAX_CARD_NUMBER_PADDING = 12;
 const CSV_HEADER_PATTERN = /^front,back$/i;
@@ -224,11 +222,11 @@ export async function loadDeckApkgAsSession(deckZipFile: File): Promise<Session>
     }
 
     const rows = db.exec(
-      "SELECT cards.id, notes.flds FROM cards JOIN notes ON notes.id = cards.nid ORDER BY cards.due ASC, cards.id ASC"
+      "SELECT cards.id, notes.flds, notes.guid FROM cards JOIN notes ON notes.id = cards.nid ORDER BY cards.due ASC, cards.id ASC"
     );
     if (rows.length > 0) {
       for (const row of rows[0].values) {
-        const [, fieldsRaw] = row;
+        const [, fieldsRaw, guidRaw] = row;
         const [frontRaw, backRaw] = String(fieldsRaw).split(FIELD_SEPARATOR);
         const front = frontRaw ?? "";
         const back = backRaw ?? "";
@@ -262,8 +260,10 @@ export async function loadDeckApkgAsSession(deckZipFile: File): Promise<Session>
           continue;
         }
 
+        const originalGuid = typeof guidRaw === "string" && guidRaw.trim().length > 0 ? guidRaw.trim() : null;
+
         cards.push({
-          id: `${APKG_CARD_ID_PREFIX}${String(cards.length + 1).padStart(APKG_CARD_ID_PADDING, "0")}`,
+          id: originalGuid ?? generateId(),
           questionRect: questionSize ? { x: 0, y: 0, w: questionSize.width, h: questionSize.height } : null,
           answerRect: answerSize ? { x: 0, y: 0, w: answerSize.width, h: answerSize.height } : null,
           questionImageSrc,

--- a/src/services/zipExporter.ts
+++ b/src/services/zipExporter.ts
@@ -340,7 +340,7 @@ export async function createDeckZip(cards: Card[], options: ZipExportOptions = {
 
         const { front, back } = buildCardHtml(card, mediaNames);
         const noteId = noteIdBase + offset;
-        const guid = sanitizeForIdentifier(`${deckPrefix}-${sequence}-${noteId.toString(36)}`);
+        const guid = sanitizeForIdentifier(card.id);
         const fields = `${front}${FIELD_SEPARATOR}${back}`;
         const checksum = hash32(front);
 

--- a/src/services/zipExporter.ts
+++ b/src/services/zipExporter.ts
@@ -196,10 +196,6 @@ function sanitizeDeckNameForAnki(deckName: string): string {
   return trimmed.length > 0 ? trimmed : "Default";
 }
 
-function sanitizeForIdentifier(value: string): string {
-  return value.replaceAll(/[^A-Za-z0-9]/g, "").slice(0, 16) || "guid";
-}
-
 export function sanitizeFileBaseName(name: string): string {
   // C0 (0-31), DEL (127), C1 (128-159) control characters
   const withoutControlChars = Array.from(name)
@@ -340,7 +336,7 @@ export async function createDeckZip(cards: Card[], options: ZipExportOptions = {
 
         const { front, back } = buildCardHtml(card, mediaNames);
         const noteId = noteIdBase + offset;
-        const guid = sanitizeForIdentifier(card.id);
+        const guid = card.id;
         const fields = `${front}${FIELD_SEPARATOR}${back}`;
         const checksum = hash32(front);
 


### PR DESCRIPTION
This pull request updates how card IDs and GUIDs are handled when importing and exporting Anki decks, ensuring better consistency and compatibility with Anki's expectations. The main change is to use the original GUID from the imported `.apkg` file (if available) as the card ID, and to use the card's ID as the GUID during export, rather than generating new or sanitized identifiers.

**Improvements to Anki deck import and export:**

* When importing `.apkg` decks, the code now reads the `notes.guid` value and uses it as the card ID if available, instead of generating a new prefixed and padded ID. This preserves original Anki GUIDs for better round-tripping and compatibility. [[1]](diffhunk://#diff-0bc4848fa6cd1db973f57656d7cc698147265625211e50d8df78fba3fd6aa389L227-R229) [[2]](diffhunk://#diff-0bc4848fa6cd1db973f57656d7cc698147265625211e50d8df78fba3fd6aa389R263-R266)
* During deck export, the card's existing `id` is now used directly as the note GUID, rather than generating a new sanitized identifier. This ensures that exported decks retain the same GUIDs as imported ones, improving consistency.

**Code cleanup:**

* The now-unused `sanitizeForIdentifier` function was removed from `src/services/zipExporter.ts` as it's no longer needed for GUID generation.
* Unused constants related to the old card ID generation scheme (`APKG_CARD_ID_PREFIX`, `APKG_CARD_ID_PADDING`) were removed from `src/services/fileManager.ts` for clarity.